### PR TITLE
fix composer install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Setup ————————————————————————————————————————————————————————————————————————
 EXEC_PHP     = php
+COMPOSER     = composer
 SYMFONY      = $(EXEC_PHP) bin/console
 SYMFONY_BIN  = symfony
 DOCKER       = docker


### PR DESCRIPTION
Impossible de faire un "make install" car il manquait la variable "$(COMPOSER)" dans le makefile